### PR TITLE
Mute stderr too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# WebStorm junk
+.idea

--- a/console.js
+++ b/console.js
@@ -1,22 +1,36 @@
 module.exports = (function foo() {
-  var saved = process.stdout.write,
-      data = [];
+  var stdoutSaved = process.stdout.write,
+      stderrSaved = process.stderr.write,
+      stdoutData = [],
+      stderrData = [];
 
   console.mute = function() {
     process.stdout.write = function(str, encoding, fd) {
-      data.push(str.replace(/\r?\n|\r/g, ''));
+      stdoutData.push(str.replace(/\r?\n|\r/g, ''));
     };
-  }
+    process.stderr.write = function (str, encoding, fd) {
+      stderrData.push(str.replace(/\r?\n|\r/g, ''));
+    }
+  };
 
   console.resume = function(preserve) {
-    process.stdout.write = saved;
+    process.stdout.write = stdoutSaved;
+    process.stderr.write = stderrSaved;
     
     if (preserve) {
-      return data;
+      return {
+        stdout: stdoutData,
+        stderr: stderrData
+      };
     } else {
-      var out = data;
-      data = [];
-      return out;
+      var outstd = stdoutData;
+      var outerr = stderrData;
+      stdoutData = [];
+      stderrData = [];
+      return {
+        stdout: outstd,
+        stderr: outerr
+      };
     }    
   }
 })();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "console.mute",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Temporarily mute the log. Resume and retrieve logged data later. For node.js",
   "main": "console.js",
   "scripts": {

--- a/tests.js
+++ b/tests.js
@@ -13,19 +13,31 @@ test('mute and resume', function(t){
   console.log('log');
   console.log('muted');
   var muted = console.resume('preserve');
-  t.equal(muted.join(), 'log,muted', 'muted data returned on resume');
+  t.equal(muted.stdout.join(), 'log,muted', 'muted stdout data returned on resume');
   
   console.mute();
   console.log('moar');
   console.log('data');
   var history = console.resume();
-  t.equal(history.join(), 'log,muted,moar,data', 'history preserved');
+  t.equal(history.stdout.join(), 'log,muted,moar,data', 'history preserved');
 
   console.mute();
   console.log('muted');
   console.log('again');
   var reset = console.resume();
-  t.equal(reset.join(), 'muted,again', 'data reset is default');
+  t.equal(reset.stdout.join(), 'muted,again', 'data reset is default');
+  
+  console.mute();
+  console.error('oh');
+  console.error('noes');
+  var mutedErr = console.resume('preserve');
+  t.equal(mutedErr.stderr.join(), 'oh,noes', 'muted stderr data returned on resume');
+  
+  console.mute();
+  console.error('dis');
+  console.error('bad');
+  var errHistory = console.resume();
+  t.equal(errHistory.stderr.join(), 'oh,noes,dis,bad', 'history preserved');
   
   t.end();
 });


### PR DESCRIPTION
What I consider to be a reasonable bare minimum extension of functionality to `stderr`, including tests.

`console.resume()` just returns an object with the contents of both muted sinks:

`{
        stdout: [<stuff that went to stdout>],
        stderr: [<stuff that went to stderr>]
      }`
