### PR TITLE
Added option keepNewLines

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ console.mute();
 console.log('b');
 var history = console.resume(); // reset history
 console.log(history.stdout); // logs ['a', 'b']
+
+// keep newlines unaltered (stripped away by default)
+console.mute({ keepNewLines: true }); // keep newlines 
+console.log('b\nc');
+var history = console.resume(); // reset history
+console.log(history.stdout); // logs ['b\nc']
+
 ```
 
 # Test

--- a/console.js
+++ b/console.js
@@ -4,12 +4,20 @@ module.exports = (function foo() {
       stdoutData = [],
       stderrData = [];
 
-  console.mute = function() {
+  console.mute = function(options) {
     process.stdout.write = function(str, encoding, fd) {
-      stdoutData.push(str.replace(/\r?\n|\r/g, ''));
+      stdoutData.push(
+        options && options.keepNewLines
+          ? str.replace(/(\r?\n|\r)$/, '')    // Only strip trailing newline
+          : str.replace(/\r?\n|\r/g, '')
+      );
     };
     process.stderr.write = function (str, encoding, fd) {
-      stderrData.push(str.replace(/\r?\n|\r/g, ''));
+      stderrData.push(
+        options && options.keepNewLines
+          ? str.replace(/(\r?\n|\r)$/, '')    // Only strip trailing newline
+          : str.replace(/\r?\n|\r/g, '')
+      );
     }
   };
 

--- a/tests.js
+++ b/tests.js
@@ -39,5 +39,17 @@ test('mute and resume', function(t){
   var errHistory = console.resume();
   t.equal(errHistory.stderr.join(), 'oh,noes,dis,bad', 'history preserved');
 
+  console.mute({ keepNewLines: false });
+  console.log('muted\r\nagain');
+  console.log('and\nagain\nand\nagain');
+  var reset = console.resume();
+  t.equal(reset.stdout.join(), 'mutedagain,andagainandagain', 'strip newlines if options.keepNewLines is false');
+
+  console.mute({ keepNewLines: true });
+  console.log('muted\r\nagain');
+  console.log('and\nagain\nand\nagain');
+  var reset = console.resume();
+  t.equal(reset.stdout.join(), 'muted\r\nagain,and\nagain\nand\nagain', 'do not strip newlines if options.keepNewLines is true');
+
   t.end();
 });


### PR DESCRIPTION
It's not always desired to strip newlines from the history, especially if you intend to read and/or print it again later. I added the option keepNewLines to console.mute so it can be optional. Made sure not to break existing behavior by defaulting to strip newlines.